### PR TITLE
Fix option selection for complex custom formatters

### DIFF
--- a/vendor/assets/javascripts/chosen/chosen.coffee
+++ b/vendor/assets/javascripts/chosen/chosen.coffee
@@ -307,7 +307,8 @@ class Chosen
     return
 
   dropdown_mousedown: (evt) ->
-    option = @parser.find_by_element(evt.target)
+    target = evt.target.closest('li')
+    option = @parser.find_by_element(target)
 
     @select(option) if option
 


### PR DESCRIPTION
If we have a custom formatter that has nested nodes inside it, we always have a chance to click on inner node instead of `<li>` itself.

Example of such formatter:
```
custom_select_formatter = ($option) ->
  source = $option.data()['source'] || { value: null, label: '', label_helper: '' }

  text = "
    <div class='flex align-items-center mvss'>
      #{ source.label_helper && "<div class='avatar avatar--30'><img class='img-circle' src='#{source.label_helper}'></div>" }
      <div class='mlm'>
        <p>#{source.label}</p>
      </div>
    </div>
  "

  return [text, source.value]
```

I used `node.closest('li')` method, please check if compatibility is good enough. If it's not we can use jquery method instead.
https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Browser_compatibility